### PR TITLE
Fix wrong union field panic

### DIFF
--- a/src/play.zig
+++ b/src/play.zig
@@ -299,23 +299,31 @@ pub fn draw_cells(view: *const View, gst: *GST, inc: f32) void {
             const scale = 1 * gst.screen_width / view.width;
 
             if (val.building == null) {
-                const texture = gst.textures.read(gst.play.maze_texture[@intFromEnum(val.tag)]).texture.tex2d;
-                texture.drawPro(
-                    .{ .x = 0, .y = 0, .width = 256, .height = 256 },
-                    .{ .x = win_pos.x, .y = win_pos.y, .width = scale + inc, .height = scale + inc },
-                    .{ .x = 0, .y = 0 },
-                    0,
-                    rl.Color.white,
-                );
+                switch (gst.textures.read(gst.play.maze_texture[@intFromEnum(val.tag)])) {
+                    .texture => |texture| {
+                        texture.tex2d.drawPro(
+                            .{ .x = 0, .y = 0, .width = 256, .height = 256 },
+                            .{ .x = win_pos.x, .y = win_pos.y, .width = scale + inc, .height = scale + inc },
+                            .{ .x = 0, .y = 0 },
+                            0,
+                            rl.Color.white,
+                        );
+                    },
+                    else => {},
+                }
             } else {
-                const texture = gst.textures.read(val.building.?.text_id).texture.tex2d;
-                texture.drawPro(
-                    .{ .x = 0, .y = 0, .width = 256, .height = 256 },
-                    .{ .x = win_pos.x, .y = win_pos.y, .width = scale + inc, .height = scale + inc },
-                    .{ .x = 0, .y = 0 },
-                    0,
-                    val.building.?.color,
-                );
+                switch (gst.textures.read(val.building.?.text_id)) {
+                    .texture => |texture| {
+                        texture.tex2d.drawPro(
+                            .{ .x = 0, .y = 0, .width = 256, .height = 256 },
+                            .{ .x = win_pos.x, .y = win_pos.y, .width = scale + inc, .height = scale + inc },
+                            .{ .x = 0, .y = 0 },
+                            0,
+                            val.building.?.color,
+                        );
+                    },
+                    else => {},
+                }
             }
         }
     }

--- a/src/tbuild.zig
+++ b/src/tbuild.zig
@@ -166,19 +166,23 @@ pub const Building = struct {
         if (color) |col| rl.drawRectangle(x, y, w, h, col) else {
             for (0..@intFromFloat(self.height)) |dy| {
                 for (0..@intFromFloat(self.width)) |dx| {
-                    const texture = gst.textures.read(self.text_id).texture.tex2d;
-                    texture.drawPro(
-                        .{ .x = 0, .y = 0, .width = 256, .height = 256 },
-                        .{
-                            .x = win_pos.x + @as(f32, @floatFromInt(dx)) * r,
-                            .y = win_pos.y + @as(f32, @floatFromInt(dy)) * r,
-                            .width = r,
-                            .height = r,
+                    switch (gst.textures.read(self.text_id)) {
+                        .texture => |texture| {
+                            texture.tex2d.drawPro(
+                                .{ .x = 0, .y = 0, .width = 256, .height = 256 },
+                                .{
+                                    .x = win_pos.x + @as(f32, @floatFromInt(dx)) * r,
+                                    .y = win_pos.y + @as(f32, @floatFromInt(dy)) * r,
+                                    .width = r,
+                                    .height = r,
+                                },
+                                .{ .x = 0, .y = 0 },
+                                0,
+                                self.color,
+                            );
                         },
-                        .{ .x = 0, .y = 0 },
-                        0,
-                        self.color,
-                    );
+                        else => {},
+                    }
                 }
             }
         }


### PR DESCRIPTION
Before, if you built with safety checks enabled, you'd sometimes run into the following: `panic: access of union field 'texture' while field 'blank' is active`. I resolved this by checking if the textures are a `texture` before rendering in a few places.

If the textures are truly never meant to be `blank` in these places, then this is indicative of a deeper issue. If you find/address this deeper issue, you don't need to merge this PR.