### PR TITLE
Minor quality of life fixes

### DIFF
--- a/src/core.zig
+++ b/src/core.zig
@@ -171,8 +171,8 @@ pub fn StateComponents(State: type) type {
 
         pub fn render(self: *Self, ctx: *Context) void {
             for (self.array_r.items) |*r| {
-                if (self.msg == null) {
-                    self.msg = r.render(ctx);
+                if (r.render(ctx)) |msg| {
+                    self.msg = msg;
                 }
             }
         }

--- a/src/main.zig
+++ b/src/main.zig
@@ -46,6 +46,7 @@ pub fn main() anyerror!void {
     rl.initWindow(@as(i32, @intFromFloat(ctx.screen_width)), @as(i32, @intFromFloat(ctx.screen_height)), "ray-game");
     defer rl.closeWindow(); // Close window and OpenGL context
 
+    rl.setExitKey(.null); // Prevent window from closing when escape key is pressed
     rl.setWindowState(.{ .window_resizable = true });
     rl.hideCursor();
     rl.setTraceLogLevel(.none);

--- a/src/main.zig
+++ b/src/main.zig
@@ -86,6 +86,8 @@ pub fn main() anyerror!void {
 }
 
 fn logic(id: Runner.StateId, ctx: *core.Context) ?Runner.StateId {
+    if (rl.windowShouldClose()) return null;
+
     rl.beginDrawing();
     if (rl.isWindowResized()) {
         ctx.screen_width = @floatFromInt(rl.getScreenWidth());

--- a/src/play.zig
+++ b/src/play.zig
@@ -122,8 +122,8 @@ pub const Place = union(enum) {
     pub fn check_inside(ctx: *Context) select.CheckInsideResult {
         const b = &ctx.play.selected_build;
         const vp = ctx.play.view.win_to_view(ctx.screen_width, rl.getMousePosition());
-        const x: i32 = @intFromFloat(@floor(vp.x - b.width / 2));
-        const y: i32 = @intFromFloat(@floor(vp.y - b.height / 2));
+        const x: i32 = @intFromFloat(@round(vp.x - b.width / 2));
+        const y: i32 = @intFromFloat(@round(vp.y - b.height / 2));
         const w: i32 = @intFromFloat(b.width);
         const h: i32 = @intFromFloat(b.height);
 
@@ -152,8 +152,8 @@ pub const Place = union(enum) {
     pub fn check_still_inside(ctx: *Context) bool {
         const b = &ctx.play.selected_build;
         const vp = ctx.play.view.win_to_view(ctx.screen_width, rl.getMousePosition());
-        const x: i32 = @intFromFloat(@floor(vp.x - b.width / 2));
-        const y: i32 = @intFromFloat(@floor(vp.y - b.height / 2));
+        const x: i32 = @intFromFloat(@round(vp.x - b.width / 2));
+        const y: i32 = @intFromFloat(@round(vp.y - b.height / 2));
         return (x == ctx.play.selected_cell_id.x and
             y == ctx.play.selected_cell_id.y);
     }

--- a/src/play.zig
+++ b/src/play.zig
@@ -122,8 +122,8 @@ pub const Place = union(enum) {
     pub fn check_inside(ctx: *Context) select.CheckInsideResult {
         const b = &ctx.play.selected_build;
         const vp = ctx.play.view.win_to_view(ctx.screen_width, rl.getMousePosition());
-        const x: i32 = @intFromFloat(@round(vp.x - b.width / 2));
-        const y: i32 = @intFromFloat(@round(vp.y - b.height / 2));
+        const x: i32 = @intFromFloat(@floor(vp.x - b.width / 2));
+        const y: i32 = @intFromFloat(@floor(vp.y - b.height / 2));
         const w: i32 = @intFromFloat(b.width);
         const h: i32 = @intFromFloat(b.height);
 
@@ -152,8 +152,8 @@ pub const Place = union(enum) {
     pub fn check_still_inside(ctx: *Context) bool {
         const b = &ctx.play.selected_build;
         const vp = ctx.play.view.win_to_view(ctx.screen_width, rl.getMousePosition());
-        const x: i32 = @intFromFloat(@round(vp.x - b.width / 2));
-        const y: i32 = @intFromFloat(@round(vp.y - b.height / 2));
+        const x: i32 = @intFromFloat(@floor(vp.x - b.width / 2));
+        const y: i32 = @intFromFloat(@floor(vp.y - b.height / 2));
         return (x == ctx.play.selected_cell_id.x and
             y == ctx.play.selected_cell_id.y);
     }


### PR DESCRIPTION
- Make it so `ray-game` window can be closed like any other window (not just by clicking `Exit` button).
- Make building placement round to the nearest grid line, rather than always rounding down.
- Make it so `StateComponents` renders components even after a `msg` has been computed, fixing the bug where some components wouldn't be rendered for a single frame after a button is pressed.